### PR TITLE
Add Open5GS dataset loader and inference mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is the basic implementation of our submission in ICSE 2021: **Semi-supervis
     + [Environment:](#environment-)
     + [Preparation](#preparation)
   * [Anomaly detection](#anomaly-detection)
+  * [Open5GS Quickstart](#open5gs-quickstart)
   * [Contact](#contact)
 
 ## Description
@@ -107,8 +108,20 @@ To those who are interested in applying PLELog on their log data, please refer t
 
 - **Step 1:** To run `PLELog` on different log data, create a directory under `datasets` folder **using unique and memorable name**(e.g. HDFS and BGL). `PLELog` will try to find the related files and create logs and results according to this name.
 - **Step 2:** Move target log file (plain text, each raw contains one log message) into the folder of step 1.
-- **Step 3:** Create a new dataloader class implementing `BasicLoader`. 
+- **Step 3:** Create a new dataloader class implementing `BasicLoader`.
 - **Step 4:** Go to `preprocessing/Preprocess.py` and add your new log data into acceptable variables.
+
+## Open5GS Quickstart
+
+The repository now bundles a loader and inference flow for the Open5GS dataset placed under `datasets/open5gs`. A detailed, end-to-end guide that walks through the training and inference commands is available in [datasets/open5gs/README.md](datasets/open5gs/README.md).
+
+At a glance, the high-level workflow is:
+
+- Prepare the environment (`pip install -r requirements.txt`) and download `datasets/glove.6B.300d.txt` if you have not already done so.
+- Run training from the project root: `python approaches/PLELog.py --dataset open5gs --parser IBM --mode train`. The first invocation collects every `.log` file under `datasets/open5gs/logs/`, trains a Drain parser, and fits the PLELog model. All parser state and model checkpoints are stored under `datasets/open5gs/persistences/` and `outputs/models/PLELog/open5gs_IBM/` respectively.
+- After training, score any new log file with `python approaches/PLELog.py --dataset open5gs --parser IBM --inference_file path/to/new.log`. Predictions are written to `outputs/results/PLELog/open5gs_IBM/inference/` as CSV files, one line per log message.
+
+See the dataset-specific README for the full procedure, expected directory structure, and troubleshooting tips.
 
 ## Contact
 

--- a/approaches/PLELog.py
+++ b/approaches/PLELog.py
@@ -1,4 +1,5 @@
 import sys
+import csv
 
 sys.path.extend([".", ".."])
 from CONSTANTS import *
@@ -12,11 +13,170 @@ from module.Optimizer import Optimizer
 from module.Common import data_iter, generate_tinsts_binary_label, batch_variable_inst
 from models.gru import AttGRUModel
 from utils.Vocab import Vocab
+from entities.instances import Instance
+from parsers.Drain_IBM import Drain3Parser
 
 lstm_hiddens = 100
 num_layer = 2
 batch_size = 100
 epochs = 5
+
+
+def _remove_columns(line, remove_cols):
+    tokens = line.strip().split()
+    return ' '.join([token for idx, token in enumerate(tokens) if idx not in remove_cols])
+
+
+def preprocess_line_for_dataset(dataset, line):
+    dataset_lower = dataset.lower()
+    if dataset_lower == 'hdfs':
+        return _remove_columns(line, [0, 1, 2, 3, 4])
+    elif dataset_lower in ('bgl', 'bglsample'):
+        return _remove_columns(line, list(range(9)))
+    else:
+        return line.rstrip('\n')
+
+
+def load_template_embeddings(embedding_file):
+    id2embed = {}
+    if not os.path.exists(embedding_file):
+        return id2embed
+    with open(embedding_file, 'r', encoding='utf-8') as reader:
+        for line in reader:
+            tokens = line.strip().split()
+            if len(tokens) <= 1:
+                continue
+            try:
+                temp_id = int(tokens[0])
+            except ValueError:
+                continue
+            vector = np.array([float(x) for x in tokens[1:]], dtype=np.float64)
+            id2embed[temp_id] = vector
+    return id2embed
+
+
+def resolve_parser_config(dataset):
+    dataset_lower = dataset.lower()
+    if dataset_lower == 'hdfs':
+        return os.path.join(PROJECT_ROOT, 'conf/HDFS.ini')
+    if dataset_lower in ('bgl', 'bglsample'):
+        return os.path.join(PROJECT_ROOT, 'conf/BGL.ini')
+    if dataset_lower == 'open5gs':
+        return os.path.join(PROJECT_ROOT, 'conf/HDFS.ini')
+    return None
+
+
+def run_inference(dataset, parser_name, inference_file, parser_config, parser_persistence,
+                  output_model_dir, threshold):
+    logger = logging.getLogger('PLELog')
+    if not inference_file:
+        logger.error('No inference file provided.')
+        return
+    if not os.path.exists(inference_file):
+        logger.error('Inference file %s not found.', inference_file)
+        return
+    if parser_config is None:
+        logger.error('No parser configuration available for dataset %s.', dataset)
+        return
+
+    drain_parser = Drain3Parser(config_file=parser_config, persistence_folder=parser_persistence)
+    if drain_parser.to_update:
+        logger.error('No trained parser state found for dataset %s. Please run training first.', dataset)
+        return
+
+    templates_embedding_file = os.path.join(drain_parser.persistence_folder, 'templates.vec')
+    id2embed = load_template_embeddings(templates_embedding_file)
+    if not id2embed:
+        logger.error('Failed to load template embeddings from %s.', templates_embedding_file)
+        return
+
+    vocab = Vocab()
+    vocab.load_from_dict(id2embed)
+    label2id = {'Normal': 0, 'Anomalous': 1}
+    plelog = PLELog(vocab, num_layer, lstm_hiddens, label2id)
+
+    log = 'layer={}_hidden={}_epoch={}'.format(num_layer, lstm_hiddens, epochs)
+    best_model_file = os.path.join(output_model_dir, log + '_best.pt')
+    last_model_file = os.path.join(output_model_dir, log + '_last.pt')
+    model_path = None
+    if os.path.exists(best_model_file):
+        model_path = best_model_file
+    elif os.path.exists(last_model_file):
+        model_path = last_model_file
+    if model_path is None:
+        logger.error('No trained model weights found under %s. Please train the model first.', output_model_dir)
+        return
+
+    plelog.model.load_state_dict(torch.load(model_path, map_location=device))
+    plelog.logger.info('Loaded model weights from %s', model_path)
+    plelog.model.eval()
+
+    id2tag = {v: k for k, v in label2id.items()}
+    inference_instances = []
+    id_to_message = {}
+    ordered_ids = []
+
+    with open(inference_file, 'r', encoding='utf-8', errors='ignore') as reader:
+        for line_idx, raw_line in enumerate(reader):
+            raw_message = raw_line.rstrip('\n')
+            processed_line = preprocess_line_for_dataset(dataset, raw_line)
+            cluster = drain_parser.match(processed_line)
+            if cluster is not None:
+                try:
+                    event_id = int(cluster.cluster_id)
+                except (TypeError, ValueError):
+                    event_id = -1
+            else:
+                event_id = -1
+
+            block_id = f"{os.path.basename(inference_file)}:{line_idx}"
+            inst = Instance(block_id, [event_id], 'Normal')
+            inference_instances.append(inst)
+            id_to_message[block_id] = raw_message
+            ordered_ids.append(block_id)
+
+    output_dir = os.path.join(PROJECT_ROOT, 'outputs',
+                               'results/PLELog/' + dataset + '_' + parser_name + '/inference')
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+    output_file = os.path.join(output_dir,
+                               os.path.splitext(os.path.basename(inference_file))[0] + '_predictions.csv')
+
+    if not inference_instances:
+        logger.warning('Inference file %s is empty. Generated an empty result file at %s.', inference_file, output_file)
+        with open(output_file, 'w', encoding='utf-8', newline='') as writer:
+            csv_writer = csv.writer(writer)
+            csv_writer.writerow(['line_number', 'block_id', 'log', 'predicted_label', 'anomaly_score'])
+        return
+
+    results = {}
+    anomaly_index = label2id['Anomalous']
+
+    with torch.no_grad():
+        plelog.model.eval()
+        for onebatch in data_iter(inference_instances, plelog.test_batch_size, False):
+            tinst = generate_tinsts_binary_label(onebatch, vocab, False)
+            tinst.to_cuda(device)
+            pred_tags, tag_logits = plelog.predict(tinst.inputs, threshold if threshold is not None else None)
+            logits_np = tag_logits.detach().cpu().numpy()
+            if isinstance(pred_tags, torch.Tensor):
+                preds_np = pred_tags.detach().cpu().numpy()
+            else:
+                preds_np = pred_tags
+            for inst, pred, prob in zip(onebatch, preds_np, logits_np):
+                results[inst.id] = {'predicted_label': id2tag[int(pred)],
+                                    'anomaly_score': float(prob[anomaly_index])}
+
+    with open(output_file, 'w', encoding='utf-8', newline='') as writer:
+        csv_writer = csv.writer(writer)
+        csv_writer.writerow(['line_number', 'block_id', 'log', 'predicted_label', 'anomaly_score'])
+        for index, block_id in enumerate(ordered_ids):
+            record = results.get(block_id, {'predicted_label': 'Normal', 'anomaly_score': 0.0})
+            csv_writer.writerow([index, block_id, id_to_message.get(block_id, ''),
+                                 record['predicted_label'],
+                                 '{:.6f}'.format(record['anomaly_score'])])
+
+    logger.info('Inference results saved to %s', output_file)
 
 
 class PLELog:
@@ -119,7 +279,7 @@ class PLELog:
 if __name__ == '__main__':
     argparser = argparse.ArgumentParser()
     argparser.add_argument('--dataset', default='HDFS', type=str, help='Target dataset. Default HDFS')
-    argparser.add_argument('--mode', default='train', type=str, help='train or test')
+    argparser.add_argument('--mode', default='train', type=str, help='train, test or inference')
     argparser.add_argument('--parser', default='IBM', type=str,
                            help='Select parser, please see parser list for detail. Default Official.')
     argparser.add_argument('--min_cluster_size', type=int, default=100,
@@ -130,6 +290,8 @@ if __name__ == '__main__':
                            help="Reduce dimentsion for fastICA, to accelerate the HDBSCAN probabilistic label estimation.")
     argparser.add_argument('--threshold', type=float, default=0.5,
                            help="Anomaly threshold for PLELog.")
+    argparser.add_argument('--inference_file', type=str, default=None,
+                           help='Run inference on the specified log file using a trained model.')
     args, extra_args = argparser.parse_known_args()
 
     dataset = args.dataset
@@ -139,6 +301,7 @@ if __name__ == '__main__':
     min_samples = args.min_samples
     reduce_dimension = args.reduce_dimension
     threshold = args.threshold
+    inference_file = args.inference_file
 
     # Mark results saving directories.
     save_dir = os.path.join(PROJECT_ROOT, 'outputs')
@@ -152,6 +315,13 @@ if __name__ == '__main__':
                               'results/PLELog/' + dataset + '_' + parser +
                               '/prob_label_res/random_state')
     save_dir = os.path.join(PROJECT_ROOT, 'outputs')
+    parser_config = resolve_parser_config(dataset)
+    parser_persistence = os.path.join(PROJECT_ROOT, 'datasets/' + dataset + '/persistences')
+
+    if inference_file:
+        run_inference(dataset, parser, inference_file, parser_config, parser_persistence,
+                      output_model_dir, threshold)
+        sys.exit(0)
 
     # Training, Validating and Testing instances.
     template_encoder = Template_TF_IDF_without_clean() if dataset == 'NC' else Simple_template_TF_IDF()

--- a/datasets/open5gs/README.md
+++ b/datasets/open5gs/README.md
@@ -1,0 +1,69 @@
+# Open5GS Training and Inference Guide
+
+This walkthrough explains how to train the bundled PLELog pipeline on the Open5GS logs that ship with this repository and how to reuse the trained artefacts for inference on any additional Open5GS log files.
+
+## Prerequisites
+
+1. Create and activate a Python 3.8+ environment.
+2. Install the runtime dependencies from the project root:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Download `glove.6B.300d.txt` from the [Stanford GloVe project](https://nlp.stanford.edu/projects/glove/) and place it at `datasets/glove.6B.300d.txt`. The representation modules look for the embeddings at this exact location.
+4. Ensure the Open5GS dataset is present under `datasets/open5gs/logs/`. The expected layout is:
+   ```
+   datasets/open5gs/logs/
+     ├── UE-INITIATED-DEREGISTRATION-PROCEDURE/
+     ├── UE-REQUESTED-PDU-SESSION-RELEASE-PROCEDURE/
+     └── UE-TRIGGERED-SERVICE-REQUEST-PROCEDURE/
+   ```
+   Each procedure directory contains one folder per network function, and those folders hold the `.log` files. Every line inside the log files is treated as an independent log message.
+
+## Training the model
+
+Run the training script from the repository root:
+
+```bash
+python approaches/PLELog.py --dataset open5gs --parser IBM --mode train
+```
+
+What this command does:
+
+- Recursively scans `datasets/open5gs/logs/` for `.log` files and flattens their contents into `datasets/open5gs/open5gs_combined.log`.
+- Learns or reuses a Drain parser with configuration `conf/HDFS.ini`. The parser state is saved under `datasets/open5gs/persistences/` for subsequent runs.
+- Generates IBM Drain inputs inside `datasets/open5gs/inputs/IBM/` and computes template embeddings using the supplied GloVe vectors.
+- Fits the PLELog model. Checkpoints are stored in `outputs/models/PLELog/open5gs_IBM/model/` (both `*_best.pt` and `*_last.pt` files when training completes).
+
+The first run may take several minutes because the parser is trained from scratch. Subsequent runs reuse the persisted Drain state and skip the expensive parsing stage.
+
+## Running inference on new logs
+
+Once training has finished (and the parser/model artefacts exist), score any Open5GS-formatted log file line-by-line:
+
+```bash
+python approaches/PLELog.py --dataset open5gs --parser IBM --inference_file path/to/your_logs.log
+```
+
+Additional notes:
+
+- Leave the dataset argument in lowercase (`open5gs`) so the loader can locate `datasets/open5gs`.
+- The script loads the saved Drain parser and model weights automatically. If either artefact is missing, rerun the training command first.
+- Set `--threshold` to change the anomaly probability cut-off (default is `0.5`).
+- Predictions are written to `outputs/results/PLELog/open5gs_IBM/inference/` as `<logname>_predictions.csv`. Each row contains the zero-based line number, the internal block identifier, the raw log line, the predicted label, and the anomaly score output by the model.
+
+## Resetting the pipeline
+
+To retrain from scratch, delete the generated artefacts before running the training command again:
+
+- Remove `datasets/open5gs/open5gs_combined.log` and the folders under `datasets/open5gs/persistences/` to force the Drain parser to relearn templates.
+- Remove `outputs/models/PLELog/open5gs_IBM/` if you want to discard saved checkpoints.
+
+These steps are optional—retraining with the artefacts in place simply updates them in-place.
+
+## Troubleshooting
+
+- **`Failed to load template embeddings` during inference** – ensure the training command completed successfully so that `datasets/open5gs/persistences/**/templates.vec` exists.
+- **`Inference file not found` error** – double-check the path passed to `--inference_file`.
+- **`glove.6B.300d.txt` related errors** – confirm that the embeddings file is available at `datasets/glove.6B.300d.txt`.
+
+After the above steps you should be able to iteratively train on the provided Open5GS logs and reuse the resulting model to analyse additional traces without modifying the code further.

--- a/preprocessing/Open5GSLoader.py
+++ b/preprocessing/Open5GSLoader.py
@@ -1,0 +1,87 @@
+import sys
+
+sys.path.extend([".", ".."])  # noqa: E402
+from CONSTANTS import *  # noqa: E402
+from preprocessing.BasicLoader import BasicDataLoader  # noqa: E402
+
+
+class Open5GSLoader(BasicDataLoader):
+    def __init__(self, logs_root=os.path.join(PROJECT_ROOT, 'datasets/open5gs/logs'),
+                 dataset_base=os.path.join(PROJECT_ROOT, 'datasets/open5gs'),
+                 semantic_repr_func=None):
+        super(Open5GSLoader, self).__init__()
+
+        self.logger = logging.getLogger('Open5GSLoader')
+        self.logger.setLevel(logging.DEBUG)
+        console_handler = logging.StreamHandler(sys.stderr)
+        console_handler.setLevel(logging.DEBUG)
+        console_handler.setFormatter(
+            logging.Formatter("%(asctime)s - %(name)s - " + SESSION + " - %(levelname)s: %(message)s"))
+
+        file_handler = logging.FileHandler(os.path.join(LOG_ROOT, 'Open5GSLoader.log'))
+        file_handler.setLevel(logging.INFO)
+        file_handler.setFormatter(
+            logging.Formatter("%(asctime)s - %(name)s - " + SESSION + " - %(levelname)s: %(message)s"))
+
+        self.logger.addHandler(console_handler)
+        self.logger.addHandler(file_handler)
+        self.logger.info(
+            'Construct Open5GSLoader logger success, current working directory: %s, logs will be written in %s',
+            os.getcwd(), LOG_ROOT)
+
+        if logs_root is None:
+            logs_root = os.path.join(PROJECT_ROOT, 'datasets/open5gs/logs')
+        if dataset_base is None:
+            dataset_base = os.path.join(PROJECT_ROOT, 'datasets/open5gs')
+
+        if not os.path.exists(logs_root):
+            self.logger.error('Log root %s not found, please check the dataset path.', logs_root)
+            exit(1)
+
+        self.logs_root = logs_root
+        self.dataset_base = dataset_base
+        if not os.path.exists(self.dataset_base):
+            os.makedirs(self.dataset_base)
+
+        self.in_file = os.path.join(self.dataset_base, 'open5gs_combined.log')
+        self.remove_cols = []
+        self.semantic_repr_func = semantic_repr_func
+        self._load_raw_log_seqs()
+
+    def logger(self):
+        return self.logger
+
+    def _pre_process(self, line):
+        return line.rstrip('\n')
+
+    def _load_raw_log_seqs(self):
+        log_paths = []
+        for root, _, files in os.walk(self.logs_root):
+            for filename in sorted(files):
+                if filename.endswith('.log'):
+                    log_paths.append(os.path.join(root, filename))
+        log_paths.sort()
+
+        if not log_paths:
+            self.logger.error('No .log files found under %s. Please verify the dataset contents.', self.logs_root)
+            exit(1)
+
+        total_lines = 0
+        self.blocks = []
+        self.block2seqs = {}
+        self.block2label = {}
+
+        with open(self.in_file, 'w', encoding='utf-8') as writer:
+            for path in log_paths:
+                relative_path = os.path.relpath(path, self.logs_root)
+                with open(path, 'r', encoding='utf-8', errors='ignore') as reader:
+                    for line_idx, raw_line in enumerate(reader):
+                        message = raw_line.rstrip('\n')
+                        writer.write(message + '\n')
+                        block_id = f"{relative_path}:{line_idx}"
+                        self.blocks.append(block_id)
+                        self.block2seqs[block_id] = [total_lines]
+                        self.block2label[block_id] = 'Normal'
+                        total_lines += 1
+
+        self.logger.info('Collected %d log lines from %d files under %s.', total_lines, len(log_paths), self.logs_root)

--- a/preprocessing/Preprocess.py
+++ b/preprocessing/Preprocess.py
@@ -2,6 +2,7 @@ from CONSTANTS import *
 from entities.instances import Instance
 from preprocessing.dataloader.BGLLoader import BGLLoader
 from preprocessing.dataloader.HDFSLoader import HDFSLoader
+from preprocessing.Open5GSLoader import Open5GSLoader
 
 
 class Preprocessor:
@@ -70,6 +71,10 @@ class Preprocessor:
             dataloader = BGLLoader(in_file=in_file, dataset_base=dataset_base,
                                    semantic_repr_func=template_encoding)
             parser_config = os.path.join(PROJECT_ROOT, 'conf/BGL.ini')
+        elif dataset == 'open5gs':
+            logs_root = os.path.join(PROJECT_ROOT, 'datasets/open5gs/logs')
+            dataloader = Open5GSLoader(logs_root=logs_root, semantic_repr_func=template_encoding)
+            parser_config = os.path.join(PROJECT_ROOT, 'conf/HDFS.ini')
 
         self.dataloader = dataloader
 


### PR DESCRIPTION
## Summary
- implement an Open5GS data loader that flattens all log files into the existing Drain-based preprocessing pipeline and register it under the `open5gs` dataset name
- extend the PLELog entrypoint to recognise the new dataset, accept an `--inference_file` argument, and reuse saved Drain/model artefacts to score new logs
- emit per-line predictions to a CSV file while keeping the rest of the training flow unchanged
- document how to train PLELog on the bundled Open5GS logs and run inference with the saved artefacts

## Testing
- python -m compileall preprocessing/Open5GSLoader.py approaches/PLELog.py


------
https://chatgpt.com/codex/tasks/task_e_68c8abf4c278832990308d82f22c01ce