### PR TITLE
Replace deprecated np.float usages

### DIFF
--- a/models/clustering.py
+++ b/models/clustering.py
@@ -93,7 +93,7 @@ class Solitary_HDBSCAN():
         '''
         predicted = []
         assert len(inputs) == len(self.labels)
-        inputs = np.asarray(inputs, dtype=np.float)
+        inputs = np.asarray(inputs, dtype=np.float64)
         self.logger.info('Summarizing labeled normals and their reprs.')
         normal_matrix = []
         for id in normal_ids:
@@ -101,7 +101,7 @@ class Solitary_HDBSCAN():
             if self.labels[id] != -1:
                 self.normal_cores.add(self.labels[id])
         self.logger.info('Normal clusters are: ' + str(self.normal_cores))
-        normal_matrix = np.asarray(normal_matrix, dtype=np.float)
+        normal_matrix = np.asarray(normal_matrix, dtype=np.float64)
         self.logger.info('Shape of normal matrix: %d x %d' % (normal_matrix.shape[0], normal_matrix.shape[1]))
 
         by_normal_core_normal = 0

--- a/preprocessing/AutoLabeling.py
+++ b/preprocessing/AutoLabeling.py
@@ -48,7 +48,7 @@ class Probabilistic_Labeling():
             labeled_inst = instances
         else:
             inputs = [inst.repr for inst in instances]
-            inputs = np.asarray(inputs, dtype=np.float)
+            inputs = np.asarray(inputs, dtype=np.float64)
             ground_truth = [inst.label for inst in instances]
 
             labels = self.model.fit_predict(inputs)
@@ -120,7 +120,7 @@ class Probabilistic_Labeling():
         with open(self.res_file, 'r', encoding='utf-8') as reader:
             for line in reader.readlines():
                 block_id, label, confidence = line.strip().split()
-                block2conf[block_id] = np.float(confidence)
+                block2conf[block_id] = float(confidence)
                 block2label[block_id] = label
         for inst in instances:
             if inst.id in block2label.keys():

--- a/preprocessing/BasicLoader.py
+++ b/preprocessing/BasicLoader.py
@@ -213,7 +213,7 @@ class BasicDataLoader():
         for line in reader.readlines():
             token = line.split()
             template_id = int(token[0])
-            embed = np.asarray(token[1:], dtype=np.float)
+            embed = np.asarray(token[1:], dtype=np.float64)
             self.id2embed[template_id] = embed
         self.logger.info('Load %d templates with embedding size %d' % (len(self.id2embed), self.id2embed[1].shape[0]))
 

--- a/representations/templates/statistics.py
+++ b/representations/templates/statistics.py
@@ -47,7 +47,7 @@ class Simple_template_TF_IDF():
                 else:
                     print(word, end=' ')
                     num_oov += 1
-            return np.asarray(return_list, dtype=np.float).sum(axis=0) / len(words)
+            return np.asarray(return_list, dtype=np.float64).sum(axis=0) / len(words)
         else:
             total_words += 1
             word = words.lower()
@@ -66,7 +66,7 @@ class Simple_template_TF_IDF():
                 for line in tqdm(reader.readlines()):
                     tokens = line.strip().split()
                     word = tokens[0]
-                    embed = np.asarray(tokens[1:], dtype=np.float)
+                    embed = np.asarray(tokens[1:], dtype=np.float64)
                     self._word2vec[word] = embed
 
                     self.vocab_size = len(tokens) - 1
@@ -171,7 +171,7 @@ class Template_TF_IDF_without_clean():
                 for line in tqdm(reader.readlines()):
                     tokens = line.strip().split()
                     word = tokens[0]
-                    embed = np.asarray(tokens[1:], dtype=np.float)
+                    embed = np.asarray(tokens[1:], dtype=np.float64)
                     self._word2vec[word] = embed
                     self.vocab_size = len(tokens) - 1
             pass


### PR DESCRIPTION
## Summary
- replace deprecated uses of `np.float` with `np.float64` when constructing numpy arrays throughout the clustering, preprocessing, and template statistics modules
- load stored confidence values with the built-in `float` type to avoid deprecated numpy aliases

## Testing
- python -m compileall .


------
https://chatgpt.com/codex/tasks/task_e_68ca121c2adc83298128915693dde003